### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ There are 2 ways you can add NSGIF to your project:
 
 Simply import the 'NSGIF' into your project then import the following in the class you want to use it: 
 ```objective-c
-#import "NSGIF.h"
+# import "NSGIF.h"
 ```      
 ### Installation with CocoaPods
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
